### PR TITLE
Use map with key path instead of tuple IDs

### DIFF
--- a/Sources/Tangerine/Tangerine.swift
+++ b/Sources/Tangerine/Tangerine.swift
@@ -8,7 +8,7 @@ public protocol Fetcher {
 
 extension URLSession: Fetcher {
   public func dataTaskPublisher(for url: URL) -> AnyPublisher<Data, URLError> {
-    self.dataTaskPublisher(for: url).map { $0.0 }.eraseToAnyPublisher()
+    self.dataTaskPublisher(for: url).map(\.data).eraseToAnyPublisher()
   }
 }
 


### PR DESCRIPTION
It's just so much nicer and clearer than `$0.0` 